### PR TITLE
implicit integer and enum conversion

### DIFF
--- a/include/RE/A/ActorState.h
+++ b/include/RE/A/ActorState.h
@@ -69,7 +69,7 @@ namespace RE
 		kWaitingForSitAnim = 2,
 
 		kIsSitting = 3,
-		kRidingMount = kIsSitting,
+		kRidingMount = static_cast<int>(kIsSitting),
 
 		kWantToStand = 4,
 


### PR DESCRIPTION
explictly cast the enum to an integer to handle compiler warnings